### PR TITLE
Update extra_compile_flags in setup.py

### DIFF
--- a/py_quic/setup.py
+++ b/py_quic/setup.py
@@ -2,15 +2,19 @@ import numpy
 from distutils.core import setup
 from distutils.extension import Extension
 from Cython.Distutils import build_ext
-import sys
+import platform
 
 
-if sys.platform == 'darwin':
+if platform.system() == 'Darwin':
+    extra_compile_args = ['-I/System/Library/Frameworks/vecLib.framework/Headers']
+    if 'ppc' in platform.machine():
+        extra_compile_args.append('-faltivec')
+        
     ext_modules = [Extension(
         name="py_quic",
         sources=["QUIC.C", "py_quic.pyx"],
         include_dirs = [numpy.get_include()],
-        extra_compile_args=['-faltivec', '-I/System/Library/Frameworks/vecLib.framework/Headers'],
+        extra_compile_args=extra_compile_args,
         extra_link_args=["-Wl,-framework", "-Wl,Accelerate"],
         language="c++"
         )]


### PR DESCRIPTION
Update extra_compile_flags logic so that altivec flag is only added if the machine is a ppc.  This should resolve compile conflicts on modern intel macs.
